### PR TITLE
Fixed logging

### DIFF
--- a/src/bin/run.sh
+++ b/src/bin/run.sh
@@ -20,6 +20,6 @@ if [ ! -d "${JAVA_HOME}" ] || [ ! -f "${JAVA_HOME}/bin/java" ]; then
     exit 1 
 fi
 
-NARVARO_HOME="$(basename pwd)"
+NARVARO_HOME="$(dirname $(pwd))"
 
 "${JAVA_HOME}/bin/java" -DnarvaroHome="${NARVARO_HOME}" -jar ../lib/startup.jar


### PR DESCRIPTION
Needed to use `dirname` instead of `basename` to get the parent level
directory
