### PR TITLE
Fix schema foreign keys and make DatabaseManager boot

### DIFF
--- a/src/database/narvaro_mysql.sql
+++ b/src/database/narvaro_mysql.sql
@@ -75,6 +75,6 @@ CREATE TABLE data
     oOther INT UNSIGNED,
     comment TEXT,
     form449 INT UNSIGNED,
-    FOREIGN KEY (park) REFERENCES (parks),
-    FOREIGN KEY (form449) REFERENCES (forms)
+    FOREIGN KEY (park) REFERENCES parks(id),
+    FOREIGN KEY (form449) REFERENCES forms(id)
 );

--- a/src/java/edu/csus/ecs/moneybeets/narvaro/Narvaro.java
+++ b/src/java/edu/csus/ecs/moneybeets/narvaro/Narvaro.java
@@ -14,9 +14,11 @@ import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.Connection;
 
 import org.apache.log4j.Logger;
 
+import edu.csus.ecs.moneybeets.narvaro.database.DatabaseManager;
 import edu.csus.ecs.moneybeets.narvaro.util.ConfigurationManager;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -123,6 +125,16 @@ public class Narvaro extends Application {
             }
             
         });
+        
+        // startup the database manager by requesting a connection
+        try {
+            Connection con = DatabaseManager.Narvaro.getConnection();
+            DatabaseManager.Narvaro.closeConnection(con);
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            return;
+        }
+        LOG.info("Database Manager Started");
         
         stage.show();
         


### PR DESCRIPTION
We do this by simply making a request for a connection, since
the manager lazily initializes the provider and connection pool.
We can then just discard the connection by asking the manager to
close it... the pool will continue to run.
